### PR TITLE
fix special chars encoding bug in predictions

### DIFF
--- a/src/main/java/org/bigml/binding/utils/Utils.java
+++ b/src/main/java/org/bigml/binding/utils/Utils.java
@@ -162,8 +162,7 @@ public class Utils {
             connection.setUseCaches (false);
 
             // Sending the body to the server
-            OutputStreamWriter output = new OutputStreamWriter(connection.getOutputStream());
-
+            OutputStreamWriter output = new OutputStreamWriter(connection.getOutputStream(), "UTF-8");
             output.write(Utils.unescapeJSONString(body));
             output.flush();
             output.close();


### PR DESCRIPTION
This PR fixes a 400 status code returned when creating a remote prediction with input data containing "special" characters. The failure was due to a missing encoding specification.

Added missing encoding spec in OutputStreamWriter instantiation.

